### PR TITLE
don't add semicolon before arrow functions

### DIFF
--- a/esformatter-semicolon-first.js
+++ b/esformatter-semicolon-first.js
@@ -90,10 +90,41 @@ function findOpening(token) {
   }
 }
 
+function shouldKeepLookingForArrow(token) {
+  if (token.type === 'Identifier') {
+    return true
+  }
+  else if (token.value === ',') {
+    return true
+  }
+  else if (token.value === ')') {
+    return true
+  }
+  else if (token.type === 'WhiteSpace') {
+    return true
+  }
+  else {
+    return false
+  }
+}
+
+function lookAheadForArrow(token) {
+  var nextToken = token.next
+
+  if (shouldKeepLookingForArrow(nextToken)) {
+    return lookAheadForArrow(nextToken)
+  }
+  else {
+    return token.next.value === '=>'
+  }
+}
+
 function shouldInsert(opening) {
   if (!opening) return;
 
   var prev = tk.findPrev(opening, tk.isCode);
-  return !prev || prev.type !== 'Punctuator' || prev.value === ')';
+  var isArrowFunction = opening.value === '(' && lookAheadForArrow(opening)
+
+  return (!prev || prev.type !== 'Punctuator' || prev.value === ')') && !isArrowFunction;
 }
 


### PR DESCRIPTION
This is to fix one of the outstanding issues on standard-format which breaks a common react idiom. 

`<div onSomething={(x) => y(x)}><foo /></div>` 
erroneously becomes 
`<div onSomething={;(x) => y(x)}><foo /></div>`

https://github.com/maxogden/standard-format/issues/174
https://github.com/maxogden/standard-format/issues/165
https://github.com/maxogden/standard-format/issues/158

There's probably a cleaner way to write this code, and there may be problems with it that I don't expect - this is my first time working with this sort of thing. Let me know if there's anything I should change!

I haven't updated with a testcase, since the preexisting one failed the first time I ran it and also it doesn't seem to like JSX.
